### PR TITLE
Set Workshop link to match current theme

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,7 +10,6 @@
     </div>
     <div class="pf-c-page__header-tools">
       {{ partial "site-navigation.html" .}}
-    <a class="navbar-item" target="_blank" href="https://play.validatedpatterns.io">Workshop</a>
       {{ partial "search-form.html" . }}
     </div>
   </header>

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -12,6 +12,11 @@
 
       </li>
       {{ end }}
+      <li class="pf-c-nav__item">
+        <a class="pf-c-nav__link" href="https://play.validatedpatterns.io" title="Workshop">
+          Workshop
+        </a>
+      </li>
     </ul>
   {{ end }}
 </nav>


### PR DESCRIPTION
Set the Workshop link to be better integrated with the theme. Without this change the spacing is incorrect in the title bar and link is blue instead of the theme colors.